### PR TITLE
API返回内容出现变化

### DIFF
--- a/src/service.ts
+++ b/src/service.ts
@@ -125,9 +125,9 @@ export class Maimai extends Service {
     }
     try {
       this.logger.info('fetching data from yuzuai alias')
-      let tmp = await this.ctx.http.get<{
+      let tmp = (await this.ctx.http.get<{
         [key: string]: { Name: string; Alias: string[] }
-      }>(this.config.yuzuai_alias)
+      }>(this.config.yuzuai_alias)).content
       for (const key of Object.keys(tmp)) {
         if (tmp[key].Alias.length) {
           for (const alias of tmp[key].Alias.filter(al => al !== tmp[key].Name)) {


### PR DESCRIPTION
尝试使用该插件，但总是加载失败，查看日志发现报错内容是Alias为undefined。
随后检查相关代码，以及尝试自行对```https://api.yuzuchan.moe/maimaidx/maimaidxalias```发出请求，发现可能以前是直接发送JSON List
```
[
    {
        "SongID": 11475,
        "Name": "super ambulance",
        "Alias": [
            "super ambulance",
            "救护车",
            ....
        ]
    },
    ......
]
```
现在是被包裹在content里面
```
{
    "status_code": 200,
    "content": [
        {
            "SongID": 11475,
            "Name": "super ambulance",
            "Alias": [
                "救护车",
                ....
            ]
        },
        ......
    ]
}
```